### PR TITLE
fix: File action does nothing when the search roots hold many files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ omarchy plugin add https://github.com/jitendradara12/omaconnect.git --enable --y
 
 - **Device & Network Monitoring**: Real-time battery level, charging indicators, LTE/5G cellular status, reachability, and pairing state.
 - **SMS & Messaging**: Direct `kdeconnect-sms` integration and inline ping/text composer.
-- **Native Omarchy File Picker**: Send files to paired devices instantly via lightweight `omarchy-menu-file`.
+- **Native Omarchy File Picker**: Send files to paired devices instantly via lightweight `omarchy-menu-select`, listing the most recently modified matches under `~/Downloads`, `~/Documents`, `~/Pictures`, and `~/Videos`.
 - **Quick Device Actions**: Ring device, sync clipboard, send files, ping, and share text or URLs.
 - **Remote Commands**: Discover and execute custom remote commands configured on target devices.
 - **Pairing Management**: Inline pair and unpair requests with safety confirmation steps.
@@ -44,7 +44,7 @@ o.bind("SUPER + SHIFT + C", "Toggle OmaConnect", "omarchy-shell shell toggle oma
 
 ## Dependencies
 
-Requires `kdeconnect`, `glib2`, `dbus`, and Omarchy's `omarchy-menu-file` command for file sharing:
+Requires `kdeconnect`, `glib2`, `dbus`, and Omarchy's `omarchy-menu-select` command for file sharing:
 
 ```bash
 sudo pacman -S kdeconnect glib2 dbus

--- a/scripts/pick_file.sh
+++ b/scripts/pick_file.sh
@@ -2,12 +2,42 @@
 set -uo pipefail
 
 if [[ -n "${OMARCHY_PATH:-}" ]]; then
-  export PATH="$OMARCHY_PATH/bin:$HOME/.local/bin:$PATH"
+    export PATH="$OMARCHY_PATH/bin:$HOME/.local/bin:$PATH"
 else
-  export PATH="$HOME/.local/bin:$PATH"
+    export PATH="$HOME/.local/bin:$PATH"
 fi
 
-paths="${HOME}/Downloads:${HOME}/Documents:${HOME}/Pictures:${HOME}/Videos"
-formats="jpg jpeg png webp gif heic avif mp4 mov m4v mkv webm avi pdf txt zip tar gz iso"
+roots=("$HOME/Downloads" "$HOME/Documents" "$HOME/Pictures" "$HOME/Videos")
+formats=(jpg jpeg png webp gif heic avif mp4 mov m4v mkv webm avi pdf txt zip tar gz iso)
 
-exec omarchy-menu-file "Select file to send" "$paths" "$formats" --width 800
+# omarchy-menu-select serialises the option list into a single argv entry for
+# perl, so the picker dies with E2BIG once that entry exceeds Linux's
+# MAX_ARG_STRLEN (32 pages, 128 KiB). The controller reads that non-zero exit as
+# a cancelled selection, so one crowded media folder silently disables sharing.
+# Offer the most recently modified matches that fit a conservative budget.
+budget_bytes=$((64 * 1024))
+
+# omarchy-menu-file aborts when any of its roots is missing, so resolve them here.
+search_roots=()
+for root in "${roots[@]}"; do
+    [[ -d $root ]] && search_roots+=("$root")
+done
+(( ${#search_roots[@]} )) || exit 1
+
+find_args=("${search_roots[@]}" "(" -type d -name ".*" ! -name "." -prune ")" -o -type f ! -name ".*" "(")
+for index in "${!formats[@]}"; do
+    (( index )) && find_args+=(-o)
+    find_args+=(-iname "*.${formats[index]}")
+done
+find_args+=(")" -printf '%T@\t%p\n')
+
+# Collect before piping: an early awk exit would otherwise surface as the
+# pipeline's SIGPIPE status and mask the menu's own exit code.
+candidates=$(find "${find_args[@]}" 2>/dev/null | sort -rn | cut -f2- |
+    LC_ALL=C awk -v budget="$budget_bytes" '
+        { budget -= length($0) + 8 }  # per-row JSON quoting overhead
+        budget < 0 { exit }
+        { print }')
+[[ -n $candidates ]] || exit 1
+
+printf '%s\n' "$candidates" | omarchy-menu-select "Select file to send" -- --width 800 --maxheight 500

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -872,7 +872,38 @@ class StateTests(unittest.TestCase):
     self.assertIn("filePickerProcess", controller_source)
     self.assertIn("getPickerScriptPath", controller_source)
     picker_sh = (ROOT / "scripts" / "pick_file.sh").read_text()
-    self.assertIn("omarchy-menu-file", picker_sh)
+    self.assertIn("omarchy-menu-select", picker_sh)
+
+  def test_file_picker_bounds_option_list_and_skips_missing_roots(self):
+    with tempfile.TemporaryDirectory() as tmp:
+        home = Path(tmp)
+        (home / "Downloads").mkdir()
+        for index in range(400):
+            entry = home / "Downloads" / f"{'n' * 200}-{index:04d}.pdf"
+            entry.write_text("x")
+            os.utime(entry, (index, index))
+
+        # Shadow the real menu so the picker's option list lands on stdout.
+        stub_dir = home / ".local" / "bin"
+        stub_dir.mkdir(parents=True)
+        stub = stub_dir / "omarchy-menu-select"
+        stub.write_text("#!/usr/bin/env bash\ncat\n")
+        stub.chmod(0o755)
+
+        result = subprocess.run(
+            ["bash", str(ROOT / "scripts" / "pick_file.sh")],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HOME": str(home), "OMARCHY_PATH": ""},
+        )
+
+    # Documents/Pictures/Videos are absent, which must not abort the picker.
+    self.assertEqual(result.returncode, 0)
+    options = result.stdout.splitlines()
+    self.assertTrue(options)
+    self.assertLess(len(options), 400)
+    self.assertLess(len(result.stdout.encode()), 128 * 1024)
+    self.assertTrue(options[0].endswith("-0399.pdf"))
 
   def test_remote_commands_unsupported_device(self):
     line = "DEVICE\tdev-unsupp\tPhone\tphone\ttrue\ttrue\t80\tfalse\tkdeconnect_ping,kdeconnect_share"


### PR DESCRIPTION
## Problem

On my machine the **File** action was a no-op — no picker, no error, no status change. Every other action worked.

`scripts/pick_file.sh` delegates to `omarchy-menu-file`, which pipes all matches into `omarchy-menu-select`. That script serialises the whole option list into a **single argv entry** for `perl`:

```bash
options_json=$(perl ... -e '...' "${options[@]}")
payload=$(perl ... -e '...' "$prompt" "$options_json" ...)
```

Linux caps any one argument at `MAX_ARG_STRLEN` (32 pages, 128 KiB), so the second `perl` call dies with `Argument list too long`. `filePickerProcess` then exits non-zero, and `KdeConnectController` reads that as a cancelled selection — hence the silence.

My `~/Documents` holds ~6800 files from a chat client's download folder, which put the list at 8377 entries / 954 KB. Reproducer:

```bash
$ bash scripts/pick_file.sh
/usr/share/omarchy/bin/omarchy-menu-select: line 87: /usr/bin/perl: Argument list too long
```

The proper long-term fix belongs upstream in Omarchy (pass the payload via stdin or a temp file), but the plugin can stay within the limit today.

## Fix

Build the candidate list in `pick_file.sh` instead of delegating to `omarchy-menu-file`, and offer the most recently modified matches that fit a conservative 64 KiB budget. The `find` expression, hidden-directory pruning and menu geometry are unchanged.

Resolving the search roots locally also fixes a second, independent failure: `omarchy-menu-file` exits 1 if **any** of its roots is missing, so the File action was equally dead for anyone without a `~/Videos` directory.

## Testing

- `scripts/validate.sh` — 50 tests pass. (`qmllint` still fails for me on host imports, identically on a clean `main`.)
- New test runs `pick_file.sh` against a temp `$HOME` containing 400 long-named files and only one of the four roots, with `omarchy-menu-select` stubbed to `cat`; asserts exit 0, a truncated newest-first list, and a payload under 128 KiB.
- Verified interactively: the picker now opens, sending works, `Esc` still exits 1 and lands in the cancelled state.