### PR TITLE
fix: accept typed empty device list

### DIFF
--- a/scripts/discover_devices.sh
+++ b/scripts/discover_devices.sh
@@ -61,7 +61,7 @@ ids=$(gdbus call --session --dest org.kde.kdeconnect --object-path "$base" \
     --method org.kde.kdeconnect.daemon.devices false false) || exit 69
 entries=$(printf '%s' "$ids" | sed -E 's/.*\[//; s/\].*//' | tr ',' '\n' \
     | sed -nE "s/^[[:space:]]*['\"]?([^'\"]+)['\"]?[[:space:]]*$/\1/p")
-[[ -n "$entries" || "$ids" =~ \(\[[[:space:]]*\],[[:space:]]*\) ]] || exit 70
+[[ -n "$entries" || "$ids" =~ ^\((@as[[:space:]]+)?\[[[:space:]]*\],[[:space:]]*\)$ ]] || exit 70
 
 is_address_reachable() {
     local addr=$1

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -849,6 +849,33 @@ class StateTests(unittest.TestCase):
     self.assertIn("sanitize_field()", discovery_source)
     self.assertIn("field=${field//$'\\t'/ }", discovery_source)
 
+  def test_discovery_accepts_typed_empty_device_array(self):
+    with tempfile.TemporaryDirectory() as tmp:
+      stub_dir = Path(tmp)
+      gdbus = stub_dir / "gdbus"
+      gdbus.write_text(
+          "#!/usr/bin/env bash\n"
+          "if [[ \"$*\" == *NameHasOwner* ]]; then\n"
+          "  printf '(true,)\\n'\n"
+          "else\n"
+          "  printf '(@as [],)\\n'\n"
+          "fi\n"
+      )
+      gdbus.chmod(0o755)
+      kdeconnect_cli = stub_dir / "kdeconnect-cli"
+      kdeconnect_cli.write_text("#!/usr/bin/env bash\nexit 0\n")
+      kdeconnect_cli.chmod(0o755)
+
+      result = subprocess.run(
+          ["bash", str(ROOT / "scripts" / "discover_devices.sh")],
+          capture_output=True,
+          text=True,
+          env={**os.environ, "PATH": f"{stub_dir}:{os.environ['PATH']}"},
+      )
+
+      self.assertEqual(result.returncode, 0, result)
+      self.assertEqual(result.stdout, "")
+
   def test_sms_launcher_reports_missing_command(self):
     sms_source = (ROOT / "scripts" / "open_sms.sh").read_text()
     self.assertIn("command -v kdeconnect-sms", sms_source)


### PR DESCRIPTION
Closes #13

## What changed

- Accept GLib's type-annotated empty string-array response, `(@as [],)`, as a valid zero-device result.
- Add a regression test that runs the real discovery script with stubbed D-Bus and KDE Connect commands.

## Root cause

`discover_devices.sh` only recognized the unannotated empty form `([],)`. Current `gdbus` emits `(@as [],)` for an empty string array, so the script exited `70`. `KdeConnectController.qml` then classified that result as KDE Connect being unavailable, leaving the panel on **daemon stopped** even while `kdeconnectd` was running.

## User impact

With KDE Connect running and no devices discovered, OmaConnect now displays **No devices found** instead of offering a Start Service button that cannot change the visible state.

## Validation

- `python3 -m unittest -q tests/test_state.py` — 52 tests pass.
- `bash -n scripts/*.sh` — passes.
- `omarchy-plugin-validate .` — passes.
- Live check with an active KDE Connect daemon and zero devices: `scripts/discover_devices.sh` exits `0`.
- The new focused test fails with exit `70` before the fix and passes afterward.

`bash scripts/validate.sh` still exits at the repository's existing `qmllint` host-import/parser diagnostic (`components/DeviceSection.qml:1: Expected token ';'`); this PR does not change QML files.