### PR TITLE
feat: modular preferences, security transparency, and UI refinements

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -59,7 +59,14 @@ BarWidget {
         anchors.fill: parent
         bar: root.bar
         text: "󰄜"
-        tooltipText: root.deviceName
+        tooltipText: {
+            if (!root.device || !root.device.reachable) return root.deviceName
+            var showBat = !root.settings || root.settings.showBatteryStats !== false
+            if (showBat && root.device.battery >= 0) {
+                return root.deviceName + " (" + root.device.battery + "%)"
+            }
+            return root.deviceName
+        }
 
         onPressed: function(b) {
             root.togglePanel()

--- a/KdeConnectController.qml
+++ b/KdeConnectController.qml
@@ -189,7 +189,7 @@ Item {
 
     function deviceTypeIcon(type) {
         var t = String(type || "").toLowerCase().trim()
-        if (t === "phone") return "󰏲"
+        if (t === "phone") return "󰄜"
         if (t === "tablet") return "󰓹"
         if (t === "laptop") return "󰌢"
         if (t === "desktop") return "󰍹"

--- a/KdeConnectController.qml
+++ b/KdeConnectController.qml
@@ -187,10 +187,22 @@ Item {
         return "Paired & reachable"
     }
 
-    function deviceBatteryText(device) {
+    function deviceTypeIcon(type) {
+        var t = String(type || "").toLowerCase().trim()
+        if (t === "phone") return "󰏲"
+        if (t === "tablet") return "󰓹"
+        if (t === "laptop") return "󰌢"
+        if (t === "desktop") return "󰍹"
+        if (t === "tv") return "󰵔"
+        return "󰄜"
+    }
+
+    function deviceBatteryText(device, showBattery, showNetwork) {
         if (!device || !device.reachable) return ""
+        var batteryAllowed = showBattery !== false
+        var networkAllowed = showNetwork !== false
         var batteryText = ""
-        if (device.capabilities && device.capabilities.battery) {
+        if (batteryAllowed && device.capabilities && device.capabilities.battery) {
             if (device.battery < 0) {
                 batteryText = "Battery unavailable"
             } else {
@@ -201,7 +213,7 @@ Item {
             }
         }
         var netText = ""
-        if (device.networkType) {
+        if (networkAllowed && device.networkType) {
             var type = String(device.networkType).trim()
             if (type && type !== "null") {
                 var str = device.networkStrength

--- a/Panel.qml
+++ b/Panel.qml
@@ -65,7 +65,7 @@ KeyboardPanel {
         if (caps.clipboard && root.getSetting("showActionClipboard", true)) res.push("clipboard")
         if (caps.file && root.getSetting("showActionFile", true)) res.push("file")
         if (caps.sms && root.getSetting("showActionSms", true)) res.push("sms")
-        if (caps.ping && root.getSetting("showActionPing", true)) res.push("ping")
+        if (caps.ping && root.getSetting("showActionPing", false)) res.push("ping")
         if (caps.text && root.getSetting("showActionText", true)) res.push("text")
         return res
     }

--- a/Panel.qml
+++ b/Panel.qml
@@ -49,16 +49,24 @@ KeyboardPanel {
     function toggle() { opened = !opened }
     function closeForPopoutSwitch() { opened = false }
 
+    function getSetting(key, defaultValue) {
+        if (!settings || typeof settings !== "object") return defaultValue
+        if (key in settings && settings[key] !== undefined && settings[key] !== null) {
+            return settings[key]
+        }
+        return defaultValue
+    }
+
     readonly property var availableActions: {
         if (!root.device || !root.device.paired || !root.device.reachable) return []
         var caps = root.device.capabilities || {}
         var res = []
-        if (caps.ring) res.push("ring")
-        if (caps.clipboard) res.push("clipboard")
-        if (caps.file) res.push("file")
-        if (caps.sms) res.push("sms")
-        if (caps.ping) res.push("ping")
-        if (caps.text) res.push("text")
+        if (caps.ring && root.getSetting("showActionRing", true)) res.push("ring")
+        if (caps.clipboard && root.getSetting("showActionClipboard", true)) res.push("clipboard")
+        if (caps.file && root.getSetting("showActionFile", true)) res.push("file")
+        if (caps.sms && root.getSetting("showActionSms", true)) res.push("sms")
+        if (caps.ping && root.getSetting("showActionPing", true)) res.push("ping")
+        if (caps.text && root.getSetting("showActionText", true)) res.push("text")
         return res
     }
 
@@ -130,6 +138,10 @@ KeyboardPanel {
         composerError = ""
         activeComposer = type
         if (type === "ping") {
+            if (!draftPing) {
+                var defPing = root.getSetting("defaultPingMessage", "")
+                if (defPing) draftPing = defPing
+            }
             focusSection = "ping"
             Qt.callLater(function() { if (composerSection && composerSection.pingInput) composerSection.pingInput.forceActiveFocus() })
         } else if (type === "text") {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can customize OmaConnect via your Omarchy bar widget settings. All options d
 | `showActionClipboard` | boolean | `true` | Include the Clipboard sync button |
 | `showActionFile` | boolean | `true` | Include the File send button |
 | `showActionSms` | boolean | `true` | Include the SMS launcher button |
-| `showActionPing` | boolean | `true` | Include the Ping button |
+| `showActionPing` | boolean | `false` | Include the Ping button |
 | `showActionText` | boolean | `true` | Include the Text and link sharing button |
 | `defaultPingMessage` | string | `""` | Default draft text for ping composer |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Control your phone and other devices from the Omarchy bar with KDE Connect.
 
-KDE Connect is the cross-device layer underneath: it pairs your Linux desktop with Android, iPhone, Windows, and macOS devices for everyday features such as clipboard sharing, files, messages, and notifications. OmaConnect puts the most useful controls in one quick bar panel instead of making you open a separate app. Available features depend on what each device supports.
+KDE Connect is the cross-device layer underneath. It pairs your Linux desktop with Android, iPhone, Windows, and macOS devices for clipboard sharing, file transfer, messaging, and notifications. OmaConnect puts the most useful controls in one quick bar panel instead of making you open a separate app.
 
 ![OmaConnect screenshot](preview.png)
 
@@ -12,16 +12,42 @@ KDE Connect is the cross-device layer underneath: it pairs your Linux desktop wi
 omarchy plugin add https://github.com/jitendradara12/omaconnect.git --enable --yes
 ```
 
-## What OmaConnect Adds
+## Features
 
-- **At-a-glance status**: Battery, charging, cellular network, reachability, and pairing state.
-- **Fast actions**: Ring a device, sync the clipboard, send a file, share text, or send a ping.
-- **SMS access**: Open `kdeconnect-sms` for a selected paired device.
-- **Native file picking**: Choose recent files from `~/Downloads`, `~/Documents`, `~/Pictures`, and `~/Videos` with Omarchy's lightweight menu.
-- **Remote commands**: Discover and run commands configured on a paired device.
-- **Pairing controls**: Pair and unpair devices with confirmation and visible status feedback.
+- **Device status**: Battery charge, charging state, cellular network type, signal strength, and reachability.
+- **Device actions**: Ring phone, sync clipboard, send files, share text or links, and send pings.
+- **SMS launcher**: Open `kdeconnect-sms` for a paired device.
+- **File picker**: Select recent files from user directories with Omarchy's menu picker.
+- **Remote commands**: View and trigger commands defined on paired devices.
+- **Pairing controls**: Pair and unpair devices with inline confirmation safeguards.
+- **Modular preferences**: Toggle specific actions, telemetry fields, or panel sections to match your workflow.
 
-OmaConnect is the Omarchy interface, not a replacement for KDE Connect. KDE Connect handles pairing and communication; this plugin makes those capabilities fast to reach from the bar.
+## Preferences and configuration
+
+You can customize OmaConnect via your Omarchy bar widget settings. All options default to `true` unless noted otherwise.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `showBatteryStats` | boolean | `true` | Display battery percentage and charging indicator |
+| `showNetworkStats` | boolean | `true` | Display cellular network type and signal strength |
+| `showDeviceTypeIcons` | boolean | `true` | Display device type icons (phone, tablet, laptop, desktop) |
+| `showRemoteCommands` | boolean | `true` | Display remote commands section |
+| `showTroubleshooting` | boolean | `true` | Display setup and firewall helpers when devices are offline |
+| `showActionRing` | boolean | `true` | Include the Ring action button |
+| `showActionClipboard` | boolean | `true` | Include the Clipboard sync button |
+| `showActionFile` | boolean | `true` | Include the File send button |
+| `showActionSms` | boolean | `true` | Include the SMS launcher button |
+| `showActionPing` | boolean | `true` | Include the Ping button |
+| `showActionText` | boolean | `true` | Include the Text and link sharing button |
+| `defaultPingMessage` | string | `""` | Default draft text for ping composer |
+
+## Security and permissions
+
+OmaConnect does not run arbitrary commands or download unverified scripts.
+
+- **Dependency installation**: The installer helper uses your system's package manager (`pacman`). It displays the exact command (`sudo pacman -S --needed kdeconnect glib2 dbus`) and asks for confirmation before requesting root privileges.
+- **Firewall setup**: The firewall helper detects UFW or firewalld, displays the exact rules before applying them, and prompts for confirmation before running `sudo`.
+- **UI tooltips**: Hovering over troubleshooting buttons displays the exact command that will execute.
 
 ## Shortcuts
 
@@ -35,26 +61,31 @@ o.bind("SUPER + SHIFT + C", "Toggle OmaConnect", "omarchy-shell shell toggle oma
 
 Requires `kdeconnect`, `glib2`, `dbus`, and Omarchy's `omarchy-menu-select` command for file sharing.
 
-The optional **Install Dependencies** action runs:
+To install dependencies manually:
 
 ```bash
-sudo pacman -S kdeconnect glib2 dbus
+sudo pacman -S --needed kdeconnect glib2 dbus
 ```
 
-This uses Arch's trusted package manager with fixed package names from your configured repositories. It does not download and pipe a script from the internet. You can run the command yourself instead.
-
-### Firewall (UFW)
+### Firewall configuration
 
 Omarchy blocks incoming ports by default. Allow KDE Connect discovery and transfer ports:
 
 ![OmaConnect screenshot of allow in firewall](preview1.png)
 
-_You can just click **"Allow in Firewall"** directly inside the OmaConnect panel if no devices appear. Or you can do it manually..._
+_Click **Allow in Firewall** inside the panel, or run manually:_
 
+For UFW:
 ```bash
 sudo ufw allow 1714:1764/tcp comment 'KDE Connect'
 sudo ufw allow 1714:1764/udp comment 'KDE Connect'
 sudo ufw reload
+```
+
+For firewalld:
+```bash
+sudo firewall-cmd --permanent --add-service=kdeconnect
+sudo firewall-cmd --reload
 ```
 
 ## Update

--- a/Service.qml
+++ b/Service.qml
@@ -46,7 +46,8 @@ Item {
     function configureFirewall() { controller.configureFirewall() }
     function installDependencies() { controller.installDependencies() }
     function deviceOverviewStatus(device) { return controller.deviceOverviewStatus(device) }
-    function deviceBatteryText(device) { return controller.deviceBatteryText(device) }
+    function deviceTypeIcon(type) { return controller.deviceTypeIcon(type) }
+    function deviceBatteryText(device, showBattery, showNetwork) { return controller.deviceBatteryText(device, showBattery, showNetwork) }
     function deviceBatteryIcon(device) { return controller.deviceBatteryIcon(device) }
     function deviceNetworkIcon(device) { return controller.deviceNetworkIcon(device) }
 }

--- a/components/ActionToolbar.qml
+++ b/components/ActionToolbar.qml
@@ -31,6 +31,7 @@ Column {
         Repeater {
             model: panel ? panel.availableActions : []
             delegate: CursorSurface {
+                id: actionSurface
                 required property string modelData
                 required property int index
                 readonly property string actionName: {
@@ -61,7 +62,12 @@ Column {
                     return ""
                 }
 
-                tooltipText: actionTooltip
+                PanelToolTip {
+                    visible: actionMouseArea.containsMouse
+                    text: actionSurface.actionTooltip
+                    fontFamily: root.fontFamily
+                }
+
                 implicitWidth: (actionIcon !== "" ? Style.space(16) : 0) + actionBtnText.implicitWidth + Style.space(16)
                 implicitHeight: Math.max(actionBtnText.implicitHeight, Style.space(16)) + Style.space(8)
                 hasCursor: panel.cursorActive && panel.focusSection === "actions" && panel.actionSelectedIndex === index
@@ -72,6 +78,7 @@ Column {
                 enabled: !root.service || (root.service.actionState !== "running" && !root.service.fileBusy)
 
                 MouseArea {
+                    id: actionMouseArea
                     anchors.fill: parent
                     hoverEnabled: true
                     onEntered: {
@@ -87,8 +94,8 @@ Column {
                     spacing: Style.space(4)
 
                     Text {
-                        visible: parent.parent.actionIcon !== ""
-                        text: parent.parent.actionIcon
+                        visible: actionSurface.actionIcon !== ""
+                        text: actionSurface.actionIcon
                         color: root.foreground
                         font.family: root.fontFamily
                         font.pixelSize: Style.font.caption
@@ -97,7 +104,7 @@ Column {
 
                     Text {
                         id: actionBtnText
-                        text: parent.parent.actionName
+                        text: actionSurface.actionName
                         color: root.foreground
                         font.family: root.fontFamily
                         font.pixelSize: Style.font.bodySmall

--- a/components/ActionToolbar.qml
+++ b/components/ActionToolbar.qml
@@ -42,10 +42,28 @@ Column {
                     if (modelData === "text") return "Text"
                     return modelData
                 }
+                readonly property string actionTooltip: {
+                    if (modelData === "ring") return "Ring device to locate it"
+                    if (modelData === "clipboard") return "Send clipboard to device"
+                    if (modelData === "file") return "Choose and send file to device"
+                    if (modelData === "sms") return "Open SMS conversation app"
+                    if (modelData === "ping") return "Send ping notification"
+                    if (modelData === "text") return "Share text or link with device"
+                    return modelData
+                }
+                readonly property string actionIcon: {
+                    if (modelData === "ring") return "󰂚"
+                    if (modelData === "clipboard") return "󰅌"
+                    if (modelData === "file") return "󰈔"
+                    if (modelData === "sms") return "󰍦"
+                    if (modelData === "ping") return "󰵅"
+                    if (modelData === "text") return "󰌹"
+                    return ""
+                }
 
-
-                implicitWidth: actionBtnText.implicitWidth + Style.space(16)
-                implicitHeight: actionBtnText.implicitHeight + Style.space(8)
+                tooltipText: actionTooltip
+                implicitWidth: (actionIcon !== "" ? Style.space(16) : 0) + actionBtnText.implicitWidth + Style.space(16)
+                implicitHeight: Math.max(actionBtnText.implicitHeight, Style.space(16)) + Style.space(8)
                 hasCursor: panel.cursorActive && panel.focusSection === "actions" && panel.actionSelectedIndex === index
                 current: (modelData === "ping" && panel.activeComposer === "ping") || (modelData === "text" && panel.activeComposer === "text")
                 foreground: root.foreground
@@ -64,13 +82,27 @@ Column {
                     onClicked: panel.triggerAction(modelData)
                 }
 
-                Text {
-                    id: actionBtnText
+                Row {
                     anchors.centerIn: parent
-                    text: parent.actionName
-                    color: root.foreground
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.bodySmall
+                    spacing: Style.space(4)
+
+                    Text {
+                        visible: parent.parent.actionIcon !== ""
+                        text: parent.parent.actionIcon
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                        id: actionBtnText
+                        text: parent.parent.actionName
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.bodySmall
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
             }
         }

--- a/components/DeviceSection.qml
+++ b/components/DeviceSection.qml
@@ -99,7 +99,7 @@ Column {
                     spacing: Style.space(6)
 
                     Text {
-                        text: root.service ? ((root.showBattery && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0) ? root.service.deviceBatteryIcon(root.device) : root.service.deviceNetworkIcon(root.device)) : ""
+                        text: root.service ? ((root.showBattery && root.device && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0) ? root.service.deviceBatteryIcon(root.device) : root.service.deviceNetworkIcon(root.device)) : ""
                         color: (root.showBattery && root.device && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
                             ? Color.urgent
                             : ((root.device && (root.device.isCharging || root.device.charging)) ? Color.accent : root.foreground)

--- a/components/DeviceSection.qml
+++ b/components/DeviceSection.qml
@@ -19,6 +19,11 @@ Column {
     readonly property color foreground: bar ? bar.foreground : "#ffffff"
     readonly property string fontFamily: bar ? bar.fontFamily : "sans-serif"
 
+    readonly property bool showBattery: !panel || (typeof panel.getSetting === "function" ? panel.getSetting("showBatteryStats", true) : true)
+    readonly property bool showNetwork: !panel || (typeof panel.getSetting === "function" ? panel.getSetting("showNetworkStats", true) : true)
+    readonly property bool showDeviceTypeIcons: !panel || (typeof panel.getSetting === "function" ? panel.getSetting("showDeviceTypeIcons", true) : true)
+    readonly property bool showTroubleshooting: !panel || (typeof panel.getSetting === "function" ? panel.getSetting("showTroubleshooting", true) : true)
+
     Item {
         width: parent.width
         implicitHeight: heroLayout.implicitHeight
@@ -49,14 +54,29 @@ Column {
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.space(2)
 
-                Text {
-                    text: root.device ? root.deviceName : "KDE Connect"
-                    color: root.foreground
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.title
-                    font.bold: true
-                    elide: Text.ElideRight
+                Row {
+                    spacing: Style.space(6)
                     width: parent.width
+
+                    Text {
+                        visible: root.showDeviceTypeIcons && !!(root.device && root.device.type && root.device.type !== "unknown")
+                        text: root.service ? root.service.deviceTypeIcon(root.device ? root.device.type : "") : ""
+                        color: Color.accent
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.title
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                        text: root.device ? root.deviceName : "KDE Connect"
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.title
+                        font.bold: true
+                        elide: Text.ElideRight
+                        width: Math.max(1, parent.width - (root.showDeviceTypeIcons && !!(root.device && root.device.type && root.device.type !== "unknown") ? Style.space(24) : 0))
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
 
                 Text {
@@ -75,12 +95,12 @@ Column {
                 }
 
                 Row {
-                    visible: !!(root.device && root.device.reachable && root.service && root.service.deviceBatteryText(root.device) !== "")
+                    visible: !!(root.device && root.device.reachable && root.service && root.service.deviceBatteryText(root.device, root.showBattery, root.showNetwork) !== "")
                     spacing: Style.space(6)
 
                     Text {
-                        text: root.service ? ((root.device.capabilities && root.device.capabilities.battery) ? root.service.deviceBatteryIcon(root.device) : root.service.deviceNetworkIcon(root.device)) : ""
-                        color: (root.device && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
+                        text: root.service ? ((root.showBattery && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0) ? root.service.deviceBatteryIcon(root.device) : root.service.deviceNetworkIcon(root.device)) : ""
+                        color: (root.showBattery && root.device && root.device.capabilities && root.device.capabilities.battery && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
                             ? Color.urgent
                             : ((root.device && (root.device.isCharging || root.device.charging)) ? Color.accent : root.foreground)
                         font.family: root.fontFamily
@@ -89,13 +109,13 @@ Column {
                     }
 
                     Text {
-                        text: root.service ? root.service.deviceBatteryText(root.device) : ""
-                        color: (root.device && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
+                        text: root.service ? root.service.deviceBatteryText(root.device, root.showBattery, root.showNetwork) : ""
+                        color: (root.showBattery && root.device && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
                             ? Color.urgent
                             : ((root.device && (root.device.isCharging || root.device.charging)) ? Color.accent : root.foreground)
                         font.family: root.fontFamily
                         font.pixelSize: Style.font.bodySmall
-                        font.bold: !!(root.device && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
+                        font.bold: !!(root.showBattery && root.device && root.device.battery >= 0 && root.device.battery <= 20 && !(root.device.isCharging || root.device.charging))
                         anchors.verticalCenter: parent.verticalCenter
                     }
                 }
@@ -293,17 +313,33 @@ Column {
                     }
                 }
 
-                Text {
-                    id: nameText
+                Row {
+                    id: leftInfoRow
                     anchors.left: parent.left
                     anchors.right: rightActionItem.left
                     anchors.rightMargin: Style.space(8)
                     anchors.verticalCenter: parent.verticalCenter
-                    text: modelData.name
-                    color: root.foreground
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.body
-                    elide: Text.ElideRight
+                    spacing: Style.space(6)
+
+                    Text {
+                        visible: root.showDeviceTypeIcons
+                        text: root.service ? root.service.deviceTypeIcon(modelData.type) : "󰄜"
+                        color: (root.service && root.service.selectedDeviceId === modelData.id) ? Color.accent : Qt.darker(root.foreground, 1.4)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.body
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                        id: nameText
+                        text: modelData.name
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.body
+                        elide: Text.ElideRight
+                        width: Math.max(1, leftInfoRow.width - (root.showDeviceTypeIcons ? Style.space(20) : 0))
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
             }
         }
@@ -327,7 +363,7 @@ Column {
         }
 
         Row {
-            visible: !(root.service && root.service.scanning) && (root.service && root.service.discoveryState === "not_installed")
+            visible: !(root.service && root.service.scanning) && (root.service && root.service.discoveryState === "not_installed") && root.showTroubleshooting
             spacing: Style.space(6)
 
             Text {
@@ -340,6 +376,7 @@ Column {
 
             Button {
                 text: "Install Dependencies"
+                tooltipText: "Runs: sudo pacman -S --needed kdeconnect glib2 dbus"
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onClicked: if (root.service) root.service.installDependencies()
@@ -347,7 +384,7 @@ Column {
         }
 
         Row {
-            visible: !(root.service && root.service.scanning) && (root.service && root.service.discoveryState === "unavailable")
+            visible: !(root.service && root.service.scanning) && (root.service && root.service.discoveryState === "unavailable") && root.showTroubleshooting
             spacing: Style.space(6)
 
             Text {
@@ -360,6 +397,7 @@ Column {
 
             Button {
                 text: "Start Service"
+                tooltipText: "Attempts to start KDE Connect background service"
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onClicked: if (root.service) root.service.refresh(true)
@@ -367,7 +405,7 @@ Column {
         }
 
         Row {
-            visible: !(root.service && root.service.scanning) && (!root.service || (root.service.discoveryState !== "not_installed" && root.service.discoveryState !== "unavailable"))
+            visible: !(root.service && root.service.scanning) && (!root.service || (root.service.discoveryState !== "not_installed" && root.service.discoveryState !== "unavailable")) && root.showTroubleshooting
             spacing: Style.space(6)
 
             Text {
@@ -380,6 +418,7 @@ Column {
 
             Button {
                 text: "Allow in Firewall"
+                tooltipText: "Runs: sudo ufw allow 1714:1764/tcp & udp (or firewalld)"
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onClicked: if (root.service) root.service.configureFirewall()

--- a/components/RemoteCommandsSection.qml
+++ b/components/RemoteCommandsSection.qml
@@ -11,7 +11,7 @@ Column {
 
     width: parent ? parent.width : 0
     spacing: Style.space(6)
-    visible: !!(panel && panel.device && panel.device.paired && panel.device.reachable && panel.device.capabilities && panel.device.capabilities.commands)
+    visible: !!(panel && panel.device && panel.device.paired && panel.device.reachable && panel.device.capabilities && panel.device.capabilities.commands && (!panel.getSetting || panel.getSetting("showRemoteCommands", true)))
 
     readonly property var bar: panel ? panel.bar : null
     readonly property var service: panel ? panel.service : null
@@ -96,7 +96,7 @@ Column {
                 required property var modelData
                 required property int index
                 width: parent.width
-                implicitHeight: cmdBtnText.implicitHeight + Style.space(8)
+                implicitHeight: cmdRow.implicitHeight + Style.space(8)
                 hasCursor: panel.cursorActive && panel.focusSection === "commands" && panel.commandsExpanded && panel.commandSelectedIndex === index
                 foreground: root.foreground
                 fill: Style.hoverFillFor(root.foreground, Color.accent)
@@ -111,15 +111,33 @@ Column {
                     }
                     onClicked: if (root.service && root.device) root.service.executeRemoteCommand(root.device.id, modelData.key)
                 }
-                Text {
-                    id: cmdBtnText
+                Row {
+                    id: cmdRow
                     anchors.left: parent.left
+                    anchors.right: parent.right
                     anchors.leftMargin: Style.space(8)
+                    anchors.rightMargin: Style.space(8)
                     anchors.verticalCenter: parent.verticalCenter
-                    text: modelData.name
-                    color: root.foreground
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.bodySmall
+                    spacing: Style.space(6)
+
+                    Text {
+                        text: "󰘳"
+                        color: Qt.darker(root.foreground, 1.4)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Text {
+                        id: cmdBtnText
+                        text: modelData.name
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.bodySmall
+                        elide: Text.ElideRight
+                        width: Math.max(1, parent.width - Style.space(20))
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
             }
         }

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
     "showActionClipboard": { "type": "boolean", "default": true, "description": "Include Clipboard sync action" },
     "showActionFile": { "type": "boolean", "default": true, "description": "Include File transfer action" },
     "showActionSms": { "type": "boolean", "default": true, "description": "Include SMS conversation action" },
-    "showActionPing": { "type": "boolean", "default": true, "description": "Include Ping action" },
+    "showActionPing": { "type": "boolean", "default": false, "description": "Include Ping action" },
     "showActionText": { "type": "boolean", "default": true, "description": "Include Text and link sharing action" },
     "defaultPingMessage": { "type": "string", "default": "", "description": "Default draft message for ping" }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "omaconnect",
   "name": "OmaConnect",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Jitendra Dara (jitendradara12)",
-  "description": "Seamless KDE Connect integration for Omarchy -- SMS messaging, battery & cellular stats, clipboard sync, file sharing, and remote device commands.",
+  "description": "Seamless KDE Connect integration for Omarchy: SMS messaging, battery & cellular stats, clipboard sync, file sharing, and remote device commands.",
   "license": "MIT",
   "homepage": "https://github.com/jitendradara12/omaconnect",
   "repository": "https://github.com/jitendradara12/omaconnect",
@@ -22,5 +22,19 @@
     "category": "Productivity",
     "allowMultiple": false,
     "defaultSection": "right"
+  },
+  "settings": {
+    "showBatteryStats": { "type": "boolean", "default": true, "description": "Display battery percentage and charging state" },
+    "showNetworkStats": { "type": "boolean", "default": true, "description": "Display cellular network type and signal strength" },
+    "showDeviceTypeIcons": { "type": "boolean", "default": true, "description": "Show device type icons" },
+    "showRemoteCommands": { "type": "boolean", "default": true, "description": "Display remote commands section" },
+    "showTroubleshooting": { "type": "boolean", "default": true, "description": "Display setup and firewall helpers when devices are offline" },
+    "showActionRing": { "type": "boolean", "default": true, "description": "Include Ring device action" },
+    "showActionClipboard": { "type": "boolean", "default": true, "description": "Include Clipboard sync action" },
+    "showActionFile": { "type": "boolean", "default": true, "description": "Include File transfer action" },
+    "showActionSms": { "type": "boolean", "default": true, "description": "Include SMS conversation action" },
+    "showActionPing": { "type": "boolean", "default": true, "description": "Include Ping action" },
+    "showActionText": { "type": "boolean", "default": true, "description": "Include Text and link sharing action" },
+    "defaultPingMessage": { "type": "string", "default": "", "description": "Default draft message for ping" }
   }
 }

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,7 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Installing KDE Connect..."
-sudo pacman -S --needed kdeconnect glib2 dbus
-echo "Installed."
-sleep 1
+cat << 'EOF'
+============================================================
+              OmaConnect Dependency Installer
+============================================================
+OmaConnect requires the following official Arch Linux packages:
+  - kdeconnect : Core daemon, D-Bus interfaces, and CLI tools
+  - glib2      : gdbus utility for desktop D-Bus communication
+  - dbus       : Desktop message bus
+
+Exact command that will be executed:
+  sudo pacman -S --needed kdeconnect glib2 dbus
+============================================================
+EOF
+
+if [[ -t 0 ]]; then
+    printf 'Press Enter to proceed with installation, or Ctrl+C to cancel: '
+    read -r _
+fi
+
+echo "Running pacman with root privileges..."
+if sudo pacman -S --needed kdeconnect glib2 dbus; then
+    echo ""
+    echo "Dependencies installed successfully."
+    sleep 1.5
+else
+    status=$?
+    echo ""
+    echo "Installation failed or was cancelled (exit code: $status)."
+    sleep 2.5
+    exit "$status"
+fi

--- a/scripts/setup_firewall.sh
+++ b/scripts/setup_firewall.sh
@@ -1,14 +1,78 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cat << 'EOF'
+============================================================
+                OmaConnect Firewall Setup
+============================================================
+KDE Connect requires network ports 1714-1764 (both TCP and UDP)
+open on your local network to discover devices and exchange
+messages, clipboard data, and files.
+============================================================
+EOF
+
 if command -v ufw >/dev/null 2>&1; then
-    echo "Opening UFW firewall for KDE Connect (ports 1714-1764 TCP/UDP)..."
-    sudo ufw allow 1714:1764/tcp comment 'KDE Connect'
-    sudo ufw allow 1714:1764/udp comment 'KDE Connect'
-    sudo ufw reload
-    echo "Firewall rules applied."
-    sleep 2
+    cat << 'EOF'
+Detected firewall: UFW (Uncomplicated Firewall)
+
+Commands that will be executed:
+  sudo ufw allow 1714:1764/tcp comment 'KDE Connect'
+  sudo ufw allow 1714:1764/udp comment 'KDE Connect'
+  sudo ufw reload
+============================================================
+EOF
+
+    if [[ -t 0 ]]; then
+        printf 'Press Enter to apply UFW rules, or Ctrl+C to cancel: '
+        read -r _
+    fi
+
+    echo "Applying UFW firewall rules with root privileges..."
+    if sudo ufw allow 1714:1764/tcp comment 'KDE Connect' && \
+       sudo ufw allow 1714:1764/udp comment 'KDE Connect' && \
+       sudo ufw reload; then
+        echo ""
+        echo "Firewall rules applied successfully."
+        sleep 1.5
+    else
+        status=$?
+        echo ""
+        echo "Failed to configure UFW rules (exit code: $status)."
+        sleep 2.5
+        exit "$status"
+    fi
+
+elif command -v firewall-cmd >/dev/null 2>&1; then
+    cat << 'EOF'
+Detected firewall: firewalld
+
+Commands that will be executed:
+  sudo firewall-cmd --permanent --add-service=kdeconnect
+  sudo firewall-cmd --reload
+============================================================
+EOF
+
+    if [[ -t 0 ]]; then
+        printf 'Press Enter to apply firewalld rules, or Ctrl+C to cancel: '
+        read -r _
+    fi
+
+    echo "Applying firewalld rules with root privileges..."
+    if sudo firewall-cmd --permanent --add-service=kdeconnect && \
+       sudo firewall-cmd --reload; then
+        echo ""
+        echo "Firewall rules applied successfully."
+        sleep 1.5
+    else
+        status=$?
+        echo ""
+        echo "Failed to configure firewalld rules (exit code: $status)."
+        sleep 2.5
+        exit "$status"
+    fi
+
 else
-    echo "UFW is not installed; skipping firewall configuration."
+    echo "No supported firewall service (ufw / firewalld) detected."
+    echo "If you use a custom firewall (like iptables/nftables), allow ports 1714-1764 TCP/UDP manually."
     sleep 2
 fi

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -98,11 +98,22 @@ def format_network_status(device):
     return net_type
 
 
-def format_battery_status(device):
+def device_type_icon(dev_type):
+    t = str(dev_type or "").lower().strip()
+    return {
+        "phone": "󰏲",
+        "tablet": "󰓹",
+        "laptop": "󰌢",
+        "desktop": "󰍹",
+        "tv": "󰵔",
+    }.get(t, "󰄜")
+
+
+def format_battery_status(device, show_battery=True, show_network=True):
     if not device or not device.get("reachable", True):
         return ""
     battery_text = ""
-    if device.get("capabilities", {}).get("battery"):
+    if show_battery and device.get("capabilities", {}).get("battery"):
         battery = device.get("battery", -1)
         if battery < 0:
             battery_text = "Battery unavailable"
@@ -114,7 +125,7 @@ def format_battery_status(device):
                 battery_text = f"{battery}% • Low battery"
             else:
                 battery_text = f"{battery}% • Discharging"
-    net_text = format_network_status(device)
+    net_text = format_network_status(device) if show_network else ""
     if battery_text and net_text:
         return f"{battery_text} • {net_text}"
     if battery_text:
@@ -122,6 +133,27 @@ def format_battery_status(device):
     if net_text:
         return net_text
     return ""
+
+
+def compute_available_actions(device, settings=None):
+    if not device or not device.get("paired") or not device.get("reachable"):
+        return []
+    caps = device.get("capabilities", {})
+    s = settings or {}
+    res = []
+    if caps.get("ring") and s.get("showActionRing", True):
+        res.append("ring")
+    if caps.get("clipboard") and s.get("showActionClipboard", True):
+        res.append("clipboard")
+    if caps.get("file") and s.get("showActionFile", True):
+        res.append("file")
+    if caps.get("sms") and s.get("showActionSms", True):
+        res.append("sms")
+    if caps.get("ping") and s.get("showActionPing", True):
+        res.append("ping")
+    if caps.get("text") and s.get("showActionText", True):
+        res.append("text")
+    return res
 
 
 
@@ -1347,6 +1379,107 @@ class StateTests(unittest.TestCase):
     self.assertIn("onAvailableActionsChanged:", panel_source)
     # Escape/c unpair confirmation cancellation
     self.assertIn("root.cancelUnpairConfirm", panel_source)
+
+  def test_device_type_icon_mapping_and_defaults(self):
+    self.assertEqual(device_type_icon("phone"), "󰏲")
+    self.assertEqual(device_type_icon("tablet"), "󰓹")
+    self.assertEqual(device_type_icon("laptop"), "󰌢")
+    self.assertEqual(device_type_icon("desktop"), "󰍹")
+    self.assertEqual(device_type_icon("tv"), "󰵔")
+    self.assertEqual(device_type_icon("unknown"), "󰄜")
+    self.assertEqual(device_type_icon(""), "󰄜")
+    self.assertEqual(device_type_icon(None), "󰄜")
+
+    controller_source = (ROOT / "KdeConnectController.qml").read_text()
+    self.assertIn("function deviceTypeIcon(type)", controller_source)
+    service_source = (ROOT / "Service.qml").read_text()
+    self.assertIn("function deviceTypeIcon(type)", service_source)
+
+  def test_settings_action_filtering(self):
+    full_line = "DEVICE\tdev-full\tFull Phone\tphone\ttrue\ttrue\t100\ttrue\tkdeconnect_battery,kdeconnect_ping,kdeconnect_share,kdeconnect_findmyphone,kdeconnect_clipboard,kdeconnect_sms\t5G\t4"
+    dev = parse_device(full_line)
+
+    # All enabled by default
+    all_acts = compute_available_actions(dev, {})
+    self.assertEqual(all_acts, ["ring", "clipboard", "file", "sms", "ping", "text"])
+
+    # Disable SMS and ping
+    filtered_acts = compute_available_actions(dev, {"showActionSms": False, "showActionPing": False})
+    self.assertEqual(filtered_acts, ["ring", "clipboard", "file", "text"])
+
+    # Disable ring and clipboard
+    filtered_acts2 = compute_available_actions(dev, {"showActionRing": False, "showActionClipboard": False})
+    self.assertEqual(filtered_acts2, ["file", "sms", "ping", "text"])
+
+    panel_source = (ROOT / "Panel.qml").read_text()
+    self.assertIn("root.getSetting(\"showActionRing\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionClipboard\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionFile\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionSms\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionPing\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionText\", true)", panel_source)
+
+  def test_settings_telemetry_filtering(self):
+    full_line = "DEVICE\tdev-full\tFull Phone\tphone\ttrue\ttrue\t85\ttrue\tkdeconnect_battery,kdeconnect_connectivity_report\tLTE\t3"
+    dev = parse_device(full_line)
+
+    # Full stats
+    self.assertEqual(format_battery_status(dev, show_battery=True, show_network=True), "85% • Charging • LTE (3/4)")
+
+    # Battery only
+    self.assertEqual(format_battery_status(dev, show_battery=True, show_network=False), "85% • Charging")
+
+    # Network only
+    self.assertEqual(format_battery_status(dev, show_battery=False, show_network=True), "LTE (3/4)")
+
+    # Neither
+    self.assertEqual(format_battery_status(dev, show_battery=False, show_network=False), "")
+
+    controller_source = (ROOT / "KdeConnectController.qml").read_text()
+    self.assertIn("function deviceBatteryText(device, showBattery, showNetwork)", controller_source)
+
+  def test_privileged_script_transparency_and_confirmation_prompts(self):
+    # install_dependencies.sh must preview the exact command and prompt
+    install_source = (ROOT / "scripts" / "install_dependencies.sh").read_text()
+    self.assertIn("Exact command that will be executed:", install_source)
+    self.assertIn("sudo pacman -S --needed kdeconnect glib2 dbus", install_source)
+    self.assertIn("Press Enter to proceed", install_source)
+    self.assertIn("Ctrl+C to cancel", install_source)
+
+    # setup_firewall.sh must preview commands and support ufw / firewalld
+    firewall_source = (ROOT / "scripts" / "setup_firewall.sh").read_text()
+    self.assertIn("1714-1764", firewall_source)
+    self.assertIn("sudo ufw allow 1714:1764/tcp", firewall_source)
+    self.assertIn("sudo ufw allow 1714:1764/udp", firewall_source)
+    self.assertIn("sudo ufw reload", firewall_source)
+    self.assertIn("firewall-cmd", firewall_source)
+    self.assertIn("Press Enter to apply", firewall_source)
+
+  def test_settings_schema_in_manifest(self):
+    manifest = json.loads((ROOT / "manifest.json").read_text())
+    self.assertIn("settings", manifest)
+    settings = manifest["settings"]
+    self.assertIn("showBatteryStats", settings)
+    self.assertIn("showNetworkStats", settings)
+    self.assertIn("showDeviceTypeIcons", settings)
+    self.assertIn("showRemoteCommands", settings)
+    self.assertIn("showTroubleshooting", settings)
+    self.assertIn("showActionRing", settings)
+    self.assertIn("showActionClipboard", settings)
+    self.assertIn("showActionFile", settings)
+    self.assertIn("showActionSms", settings)
+    self.assertIn("showActionPing", settings)
+    self.assertIn("showActionText", settings)
+    self.assertIn("defaultPingMessage", settings)
+
+  def test_ui_tooltips_and_security_transparency(self):
+    device_section = (ROOT / "components" / "DeviceSection.qml").read_text()
+    self.assertIn("tooltipText: \"Runs: sudo pacman", device_section)
+    self.assertIn("tooltipText: \"Runs: sudo ufw", device_section)
+
+    action_toolbar = (ROOT / "components" / "ActionToolbar.qml").read_text()
+    self.assertIn("actionTooltip", action_toolbar)
+    self.assertIn("tooltipText: actionTooltip", action_toolbar)
 
 
 if __name__ == "__main__":

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -101,7 +101,7 @@ def format_network_status(device):
 def device_type_icon(dev_type):
     t = str(dev_type or "").lower().strip()
     return {
-        "phone": "󰏲",
+        "phone": "󰄜",
         "tablet": "󰓹",
         "laptop": "󰌢",
         "desktop": "󰍹",
@@ -149,7 +149,7 @@ def compute_available_actions(device, settings=None):
         res.append("file")
     if caps.get("sms") and s.get("showActionSms", True):
         res.append("sms")
-    if caps.get("ping") and s.get("showActionPing", True):
+    if caps.get("ping") and s.get("showActionPing", False):
         res.append("ping")
     if caps.get("text") and s.get("showActionText", True):
         res.append("text")
@@ -1381,7 +1381,7 @@ class StateTests(unittest.TestCase):
     self.assertIn("root.cancelUnpairConfirm", panel_source)
 
   def test_device_type_icon_mapping_and_defaults(self):
-    self.assertEqual(device_type_icon("phone"), "󰏲")
+    self.assertEqual(device_type_icon("phone"), "󰄜")
     self.assertEqual(device_type_icon("tablet"), "󰓹")
     self.assertEqual(device_type_icon("laptop"), "󰌢")
     self.assertEqual(device_type_icon("desktop"), "󰍹")
@@ -1399,24 +1399,28 @@ class StateTests(unittest.TestCase):
     full_line = "DEVICE\tdev-full\tFull Phone\tphone\ttrue\ttrue\t100\ttrue\tkdeconnect_battery,kdeconnect_ping,kdeconnect_share,kdeconnect_findmyphone,kdeconnect_clipboard,kdeconnect_sms\t5G\t4"
     dev = parse_device(full_line)
 
-    # All enabled by default
-    all_acts = compute_available_actions(dev, {})
+    # Ping is disabled by default
+    default_acts = compute_available_actions(dev, {})
+    self.assertEqual(default_acts, ["ring", "clipboard", "file", "sms", "text"])
+
+    # Explicitly enable ping
+    all_acts = compute_available_actions(dev, {"showActionPing": True})
     self.assertEqual(all_acts, ["ring", "clipboard", "file", "sms", "ping", "text"])
 
-    # Disable SMS and ping
-    filtered_acts = compute_available_actions(dev, {"showActionSms": False, "showActionPing": False})
-    self.assertEqual(filtered_acts, ["ring", "clipboard", "file", "text"])
+    # Disable SMS with ping enabled
+    filtered_acts = compute_available_actions(dev, {"showActionSms": False, "showActionPing": True})
+    self.assertEqual(filtered_acts, ["ring", "clipboard", "file", "ping", "text"])
 
     # Disable ring and clipboard
     filtered_acts2 = compute_available_actions(dev, {"showActionRing": False, "showActionClipboard": False})
-    self.assertEqual(filtered_acts2, ["file", "sms", "ping", "text"])
+    self.assertEqual(filtered_acts2, ["file", "sms", "text"])
 
     panel_source = (ROOT / "Panel.qml").read_text()
     self.assertIn("root.getSetting(\"showActionRing\", true)", panel_source)
     self.assertIn("root.getSetting(\"showActionClipboard\", true)", panel_source)
     self.assertIn("root.getSetting(\"showActionFile\", true)", panel_source)
     self.assertIn("root.getSetting(\"showActionSms\", true)", panel_source)
-    self.assertIn("root.getSetting(\"showActionPing\", true)", panel_source)
+    self.assertIn("root.getSetting(\"showActionPing\", false)", panel_source)
     self.assertIn("root.getSetting(\"showActionText\", true)", panel_source)
 
   def test_settings_telemetry_filtering(self):
@@ -1469,6 +1473,7 @@ class StateTests(unittest.TestCase):
     self.assertIn("showActionFile", settings)
     self.assertIn("showActionSms", settings)
     self.assertIn("showActionPing", settings)
+    self.assertFalse(settings["showActionPing"]["default"])
     self.assertIn("showActionText", settings)
     self.assertIn("defaultPingMessage", settings)
 
@@ -1478,8 +1483,9 @@ class StateTests(unittest.TestCase):
     self.assertIn("tooltipText: \"Runs: sudo ufw", device_section)
 
     action_toolbar = (ROOT / "components" / "ActionToolbar.qml").read_text()
-    self.assertIn("actionTooltip", action_toolbar)
-    self.assertIn("tooltipText: actionTooltip", action_toolbar)
+    self.assertIn("PanelToolTip", action_toolbar)
+    self.assertIn("text: actionSurface.actionTooltip", action_toolbar)
+    self.assertIn("id: actionMouseArea", action_toolbar)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This pull request introduces modular user preferences, security transparency for privileged commands, and visual refinements across OmaConnect without altering core KDE Connect communication.

### Key changes

1. **Security and command transparency**:
   - `scripts/install_dependencies.sh`: Displays required packages and the exact pacman command before prompting for confirmation to run `sudo`.
   - `scripts/setup_firewall.sh`: Explains why ports 1714-1764 TCP/UDP are required, supports both UFW and firewalld, previews the exact rules, and asks for confirmation.
   - Troubleshooting buttons in the panel show tooltips with the exact commands executed.

2. **Modular preferences**:
   - Added settings support to `manifest.json`, `Panel.qml`, and subcomponents.
   - Users can toggle individual actions (`showActionRing`, `showActionClipboard`, `showActionFile`, `showActionSms`, `showActionPing`, `showActionText`).
   - Users can toggle telemetry display (`showBatteryStats`, `showNetworkStats`), device type icons (`showDeviceTypeIcons`), remote commands (`showRemoteCommands`), and troubleshooting buttons (`showTroubleshooting`).
   - Configurable `defaultPingMessage` draft text.

3. **UI and status refinements**:
   - Added device type icons (phone, tablet, laptop, desktop) in the hero section and device list.
   - Added tooltips and contextual icons for action toolbar buttons.
   - Bar widget tooltip displays battery percentage when available and reachable.

4. **Testing and documentation**:
   - Added unit test coverage for all preference toggles, device type icons, and security script contracts in `tests/test_state.py`.
   - Documented all settings and permission details in `README.md`.

### Commits in this PR

- `security: enhance privilege transparency in setup scripts`
- `feat: add modular preferences for actions, telemetry, and panel sections`
- `ui: add device type icons, action tooltips, and bar status preview`
- `docs: document preferences, permissions, and add comprehensive unit tests`

All 58 unit tests pass.