### PR TITLE
Theme KDE Connect's windows and fix SMS contact names

### DIFF
--- a/KdeConnectController.qml
+++ b/KdeConnectController.qml
@@ -336,6 +336,22 @@ Item {
         installProcess.running = true
     }
 
+    function getKdeThemeScriptPath() {
+        return scriptPath("scripts/setup_kde_theme.sh")
+    }
+
+    // kdeconnect-sms and kdeconnect-app are Kirigami apps: they colour
+    // themselves from KColorScheme (~/.config/kdeglobals), which the Omarchy
+    // theme never writes, so they open in Breeze light on a dark desktop. The
+    // helper installs a theme template plus a theme-set hook that keep that
+    // file in step with whatever theme is active.
+    function setupKdeTheme() {
+        if (kdeThemeProcess.running) return
+        var script = getKdeThemeScriptPath()
+        kdeThemeProcess.command = ["bash", "-c", "if command -v omarchy-launch-floating-terminal-with-presentation >/dev/null 2>&1; then omarchy-launch-floating-terminal-with-presentation \"bash '" + script + "'\"; else xdg-terminal-exec bash '" + script + "'; fi"]
+        kdeThemeProcess.running = true
+    }
+
     function refresh(forceNetwork) {
         if (forceNetwork) refreshTailscale()
         if (scanProcess.running) {
@@ -1033,6 +1049,10 @@ Item {
         onExited: function(code) {
             root.refresh(true)
         }
+    }
+
+    Process {
+        id: kdeThemeProcess
     }
 
     Process {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ o.bind("SUPER + SHIFT + C", "Toggle OmaConnect", "omarchy-shell shell toggle oma
 
 ## Dependencies
 
-Requires `kdeconnect`, `glib2`, `dbus`, and `omarchy-menu-select` (for file sharing). `tailscale` and `kdeconnect-sms` are optional.
+Requires `kdeconnect`, `glib2`, `dbus`, and `omarchy-menu-select` (for file sharing). `tailscale` and `kdeconnect-sms` are optional, as is `kpeoplevcard` (AUR) for [contact names in SMS](#contact-names-in-sms).
 
 ```bash
 sudo pacman -S --needed kdeconnect glib2 dbus
@@ -74,6 +74,39 @@ sudo ufw allow 1714:1764/tcp comment 'KDE Connect'
 sudo ufw allow 1714:1764/udp comment 'KDE Connect'
 sudo ufw reload
 ```
+
+### Matching your Omarchy theme
+
+OmaConnect's own panel is drawn with Omarchy's `qs.Ui` components, so it follows your theme already. The windows it opens do not: `kdeconnect-sms` and `kdeconnect-app` are Kirigami apps, and Kirigami takes its palette from `KColorScheme`, which reads `~/.config/kdeglobals`. `QT_QPA_PLATFORMTHEME` never reaches that palette, so with no `kdeglobals` present those apps fall back to Breeze *light* — a bright window on a dark desktop.
+
+Click **Match Omarchy Theme** in the panel, or run it directly:
+
+```bash
+bash ~/.config/omarchy/plugins/omaconnect/scripts/setup_kde_theme.sh
+```
+
+It installs two ordinary Omarchy extension points and needs no root:
+
+| File | Purpose |
+| --- | --- |
+| `~/.config/omarchy/themed/kdeglobals.tpl` | renders the active palette into KDE's color-scheme format |
+| `~/.config/omarchy/hooks/theme-set.d/kde-globals` | installs the rendered file on every theme change |
+
+Colors are derived from `colors.toml` keys that `omarchy-theme-color` resolves for every theme, and surfaces are mixed between `background` and `foreground` rather than hardcoded, so light themes stay light. Any existing `kdeglobals` is backed up first. Restart an open KDE app to pick up a new scheme — they read the palette once at startup.
+
+Nothing here is specific to KDE Connect; Dolphin, Gwenview, Okular and Ark follow the theme too.
+
+### Contact names in SMS
+
+`kdeconnect-sms` lists every conversation by phone number unless the `kpeoplevcard` KPeople backend is installed. KDE Connect syncs your phone's address book into `~/.local/share/kpeoplevcard/kdeconnect-<device-id>/` as vCards, but nothing reads them without that backend.
+
+It is an AUR package, so it is offered as an optional step by **Install Dependencies** rather than bundled with the required ones:
+
+```bash
+yay -S kpeoplevcard
+```
+
+Then enable the Contacts plugin in KDE Connect on Android and grant it the Contacts permission. Names appear after the next sync; restart `kdeconnect-sms` to pick them up.
 
 ## Update
 

--- a/assets/hooks/theme-set.d/kde-globals
+++ b/assets/hooks/theme-set.d/kde-globals
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Install the theme-rendered KDE color scheme so KDE Frameworks apps
+# (kdeconnect-sms, kdeconnect-app, dolphin, gwenview, okular, ark, ...)
+# follow the active Omarchy theme.
+#
+# Kirigami and KColorScheme read ~/.config/kdeglobals directly and ignore
+# QT_QPA_PLATFORMTHEME. Without this file they render with Breeze *light*
+# defaults regardless of the desktop theme.
+#
+# The file itself is produced by ~/.config/omarchy/themed/kdeglobals.tpl,
+# which omarchy-theme-set-templates renders before this hook runs.
+
+set -euo pipefail
+
+rendered="$HOME/.local/state/omarchy/current/theme/kdeglobals"
+target="$HOME/.config/kdeglobals"
+
+# Themes without a colors.toml render no templates; leave any existing file be.
+[[ -f $rendered ]] || exit 0
+
+mkdir -p "$(dirname "$target")"
+install -m 0644 "$rendered" "$target"
+
+# Already-running KDE apps cache the palette at startup and must be
+# relaunched to pick up a new scheme; nothing to signal here.
+exit 0

--- a/assets/themed/kdeglobals.tpl
+++ b/assets/themed/kdeglobals.tpl
@@ -1,0 +1,163 @@
+# Omarchy user template: KDE / Kirigami color scheme (installed by OmaConnect)
+#
+# Qt apps built on KDE Frameworks (kdeconnect-sms, kdeconnect-app, dolphin,
+# gwenview, okular, ark, ...) do NOT take their colors from QT_QPA_PLATFORMTHEME.
+# Kirigami and KColorScheme read ~/.config/kdeglobals, and when that file is
+# missing they fall back to Breeze *light* defaults -- which is why a KDE app
+# shows up as a bright window on an otherwise dark Omarchy desktop.
+#
+# This template renders the active Omarchy palette into that file's format, so
+# KDE apps track whatever theme is set. The companion hook
+# ~/.config/omarchy/hooks/theme-set.d/kde-globals copies the rendered result
+# into place on every theme change.
+#
+# Everything is derived from colors.toml keys that omarchy-theme-color resolves
+# for every theme, and surfaces are mixed between background and foreground
+# rather than hardcoded, so the scheme stays correct for light themes too.
+
+[General]
+ColorScheme=Omarchy
+shadeSortColumn=true
+
+[KDE]
+contrast=4
+
+[Colors:Window]
+BackgroundNormal={{ background_rgb }}
+BackgroundAlternate={{ mix_rgb background foreground 7 }}
+ForegroundNormal={{ foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:View]
+BackgroundNormal={{ mix_rgb background foreground 4 }}
+BackgroundAlternate={{ mix_rgb background foreground 8 }}
+ForegroundNormal={{ foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Button]
+BackgroundNormal={{ mix_rgb background foreground 12 }}
+BackgroundAlternate={{ mix_rgb background foreground 18 }}
+ForegroundNormal={{ foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Selection]
+BackgroundNormal={{ accent_rgb }}
+BackgroundAlternate={{ accent_rgb }}
+ForegroundNormal={{ background_rgb }}
+ForegroundInactive={{ mix_rgb background accent 30 }}
+ForegroundActive={{ background_rgb }}
+ForegroundLink={{ background_rgb }}
+ForegroundVisited={{ background_rgb }}
+ForegroundNegative={{ background_rgb }}
+ForegroundNeutral={{ background_rgb }}
+ForegroundPositive={{ background_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Tooltip]
+BackgroundNormal={{ mix_rgb background foreground 14 }}
+BackgroundAlternate={{ mix_rgb background foreground 20 }}
+ForegroundNormal={{ bright_foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Complementary]
+BackgroundNormal={{ mix_rgb background foreground 6 }}
+BackgroundAlternate={{ mix_rgb background foreground 12 }}
+ForegroundNormal={{ foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Header]
+BackgroundNormal={{ mix_rgb background foreground 6 }}
+BackgroundAlternate={{ mix_rgb background foreground 10 }}
+ForegroundNormal={{ foreground_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[Colors:Header][Inactive]
+BackgroundNormal={{ mix_rgb background foreground 4 }}
+BackgroundAlternate={{ mix_rgb background foreground 8 }}
+ForegroundNormal={{ muted_rgb }}
+ForegroundInactive={{ muted_rgb }}
+ForegroundActive={{ accent_rgb }}
+ForegroundLink={{ blue_rgb }}
+ForegroundVisited={{ magenta_rgb }}
+ForegroundNegative={{ red_rgb }}
+ForegroundNeutral={{ yellow_rgb }}
+ForegroundPositive={{ green_rgb }}
+DecorationFocus={{ accent_rgb }}
+DecorationHover={{ accent_rgb }}
+
+[WM]
+activeBackground={{ mix_rgb background foreground 6 }}
+activeForeground={{ bright_foreground_rgb }}
+activeBlend={{ accent_rgb }}
+inactiveBackground={{ background_rgb }}
+inactiveForeground={{ muted_rgb }}
+inactiveBlend={{ background_rgb }}
+
+[ColorEffects:Disabled]
+Color={{ muted_rgb }}
+ColorAmount=0
+ColorEffect=0
+ContrastAmount=0.65
+ContrastEffect=1
+IntensityAmount=0.1
+IntensityEffect=2
+
+[ColorEffects:Inactive]
+ChangeSelectionColor=true
+Color={{ muted_rgb }}
+ColorAmount=0.025
+ColorEffect=2
+ContrastAmount=0.1
+ContrastEffect=2
+Enable=false
+IntensityAmount=0
+IntensityEffect=0

--- a/components/DeviceSection.qml
+++ b/components/DeviceSection.qml
@@ -516,5 +516,30 @@ Column {
                 onClicked: if (root.service) root.service.configureFirewall()
             }
         }
+
+        // KDE Connect's own windows are Kirigami apps and take their colours
+        // from ~/.config/kdeglobals, not from the Omarchy theme, so they open
+        // in Breeze light until that file exists.
+        Row {
+            visible: root.showTroubleshooting
+            spacing: Style.space(6)
+
+            Text {
+                text: "KDE windows unthemed?"
+                color: Qt.darker(root.foreground, 1.4)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Button {
+                text: "Match Omarchy Theme"
+                tooltipText: "Generates ~/.config/kdeglobals from the active theme, and keeps it in sync on theme change. No root needed."
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                fontSize: Style.font.bodySmall
+                onClicked: if (root.service) root.service.setupKdeTheme()
+            }
+        }
     }
 }

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -32,3 +32,96 @@ else
     sleep 2.5
     exit "$status"
 fi
+
+# ---------------------------------------------------------------------------
+# Optional: contact names in the SMS app.
+#
+# KDE Connect's contacts plugin writes the phone's address book into
+# ~/.local/share/kpeoplevcard/kdeconnect-<device-id>/ as vCards, but nothing
+# reads them unless the kpeoplevcard KPeople backend is installed. Without it
+# kdeconnect-sms has no way to map a number to a name, so every conversation is
+# listed as a bare phone number.
+#
+# kpeoplevcard is not in the official repositories, so this step needs an AUR
+# helper and is kept separate from the required packages above.
+# ---------------------------------------------------------------------------
+
+if pacman -Qq kpeoplevcard >/dev/null 2>&1; then
+    echo ""
+    echo "kpeoplevcard already installed; SMS contact names are supported."
+    sleep 1.5
+    exit 0
+fi
+
+aur_helper=""
+for candidate in yay paru; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        aur_helper="$candidate"
+        break
+    fi
+done
+
+cat << 'EOF'
+
+============================================================
+      Optional: show contact names instead of numbers
+============================================================
+kdeconnect-sms lists every conversation by phone number unless the
+kpeoplevcard KPeople backend is installed. It reads the vCards that
+KDE Connect syncs from your phone and resolves them to names.
+
+This package lives in the AUR, not the official repositories.
+============================================================
+EOF
+
+if [[ -z $aur_helper ]]; then
+    cat << 'EOF'
+No AUR helper (yay or paru) was found, so this step is being skipped.
+Install it later with, for example:
+
+  yay -S kpeoplevcard
+
+Then grant KDE Connect the Contacts permission on your phone and
+re-pair or refresh so the vCards sync across.
+EOF
+    sleep 2.5
+    exit 0
+fi
+
+if [[ -t 0 ]]; then
+    printf 'Install kpeoplevcard with %s? [y/N]: ' "$aur_helper"
+    read -r reply
+    case "$reply" in
+        [yY] | [yY][eE][sS]) ;;
+        *)
+            echo "Skipped. You can run '$aur_helper -S kpeoplevcard' later."
+            sleep 1.5
+            exit 0
+            ;;
+    esac
+else
+    # Non-interactive runs must not pull in an AUR package unprompted.
+    echo "Non-interactive run; skipping the optional AUR step."
+    echo "Run '$aur_helper -S kpeoplevcard' to enable SMS contact names."
+    exit 0
+fi
+
+if "$aur_helper" -S --needed kpeoplevcard; then
+    cat << 'EOF'
+
+kpeoplevcard installed.
+
+One more step happens on the phone: open KDE Connect on Android, make
+sure the Contacts plugin is enabled, and grant the Contacts permission.
+Names appear after the next sync; restart kdeconnect-sms to pick them up.
+EOF
+    sleep 2.5
+else
+    status=$?
+    echo ""
+    echo "kpeoplevcard installation failed or was cancelled (exit code: $status)."
+    echo "OmaConnect still works; conversations stay listed by number."
+    sleep 2.5
+fi
+
+exit 0

--- a/scripts/setup_kde_theme.sh
+++ b/scripts/setup_kde_theme.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Make KDE Frameworks apps follow the active Omarchy theme.
+#
+# OmaConnect's own panel is drawn with Omarchy's qs.Ui components, so it is
+# themed already. The apps it launches are not: kdeconnect-sms and
+# kdeconnect-app are Kirigami apps, and Kirigami takes its palette from
+# KColorScheme, which reads ~/.config/kdeglobals. QT_QPA_PLATFORMTHEME never
+# reaches that palette. With no kdeglobals present, KColorScheme falls back to
+# Breeze *light* defaults -- a bright window on a dark desktop.
+#
+# This installs two files into the user's Omarchy config:
+#
+#   ~/.config/omarchy/themed/kdeglobals.tpl        renders the active palette
+#   ~/.config/omarchy/hooks/theme-set.d/kde-globals installs it on theme change
+#
+# Both are plain Omarchy extension points, so the scheme is regenerated for
+# whatever theme is set afterwards. Nothing here is specific to KDE Connect;
+# dolphin, gwenview, okular and ark pick it up too.
+
+plugin_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+config_dir="$HOME/.config/omarchy"
+themed_dir="$config_dir/themed"
+hooks_dir="$config_dir/hooks/theme-set.d"
+kdeglobals="$HOME/.config/kdeglobals"
+
+template_src="$plugin_dir/assets/themed/kdeglobals.tpl"
+hook_src="$plugin_dir/assets/hooks/theme-set.d/kde-globals"
+
+cat <<'BANNER'
+============================================================
+        OmaConnect: match KDE apps to your Omarchy theme
+============================================================
+kdeconnect-sms and kdeconnect-app are KDE (Kirigami) apps. They
+read their colors from ~/.config/kdeglobals, not from the Omarchy
+theme, so without that file they render in Breeze light.
+
+This installs an Omarchy theme template and a theme-set hook that
+generate that file from your active theme, and keep it in sync
+whenever you switch themes.
+
+Files written:
+  ~/.config/omarchy/themed/kdeglobals.tpl
+  ~/.config/omarchy/hooks/theme-set.d/kde-globals
+  ~/.config/kdeglobals            (generated; existing file backed up)
+
+No root privileges are used.
+============================================================
+BANNER
+
+if [[ ! -f $template_src || ! -f $hook_src ]]; then
+    printf 'error: plugin assets missing under %s/assets\n' "$plugin_dir" >&2
+    exit 1
+fi
+
+if [[ ! -x "$(command -v omarchy-theme-set 2>/dev/null || true)" ]]; then
+    printf 'error: omarchy-theme-set not found; this needs Omarchy on PATH\n' >&2
+    exit 1
+fi
+
+if [[ -t 0 ]]; then
+    printf 'Press Enter to install, or Ctrl+C to cancel: '
+    read -r _
+fi
+
+# An existing kdeglobals is almost always hand-written or Plasma-managed.
+# Keep a dated copy rather than silently replacing someone's color scheme.
+if [[ -f $kdeglobals && ! -L $kdeglobals ]]; then
+    backup="$kdeglobals.omaconnect-backup.$(date +%Y%m%d%H%M%S)"
+    cp -p "$kdeglobals" "$backup"
+    printf 'Backed up existing kdeglobals to %s\n' "$backup"
+fi
+
+mkdir -p "$themed_dir" "$hooks_dir"
+install -m 0644 "$template_src" "$themed_dir/kdeglobals.tpl"
+install -m 0755 "$hook_src" "$hooks_dir/kde-globals"
+printf 'Installed template and theme-set hook.\n'
+
+# Templates are rendered by omarchy-theme-set, so re-apply the current theme to
+# generate kdeglobals now instead of waiting for the next theme switch.
+theme_name_file="$HOME/.local/state/omarchy/current/theme.name"
+if [[ -r $theme_name_file ]]; then
+    current_theme="$(tr -d '[:space:]' <"$theme_name_file")"
+else
+    current_theme=""
+fi
+
+if [[ -n $current_theme ]]; then
+    printf 'Re-applying theme "%s" to render the color scheme...\n' "$current_theme"
+    if omarchy-theme-set "$current_theme"; then
+        printf 'Done.\n'
+    else
+        printf 'warning: could not re-apply the theme; switch themes once to generate the file\n' >&2
+    fi
+else
+    printf 'Could not read the current theme name; switch themes once to generate the file.\n'
+fi
+
+if [[ -f $kdeglobals ]]; then
+    printf '\nColor scheme active at %s\n' "$kdeglobals"
+    printf 'Restart any open KDE app -- they read the palette once at startup.\n'
+else
+    printf '\nwarning: %s was not generated; check that your theme ships a colors.toml\n' "$kdeglobals" >&2
+fi
+
+if [[ -t 0 ]]; then
+    sleep 2
+fi
+
+exit 0

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_dir"
 
 python3 -m unittest -q tests/test_state.py


### PR DESCRIPTION
OmaConnect's own panel already follows the Omarchy theme — it's built from `qs.Ui` components and `Style`/`Color` tokens. The windows it *launches* don't, and on a dark desktop `kdeconnect-sms` opens as a bright white window.

## Why the KDE windows aren't themed

`kdeconnect-sms` and `kdeconnect-app` are Kirigami apps. Kirigami colours itself from `KColorScheme`, which reads `~/.config/kdeglobals` — `QT_QPA_PLATFORMTHEME` never reaches that palette. With no `kdeglobals` present, `KColorScheme` falls back to Breeze **light** regardless of the desktop theme. On a stock Omarchy install that file doesn't exist, so every user hits this.

This adds a theme bridge built entirely from Omarchy's own extension points — nothing bespoke, nothing patched:

| File | Purpose |
| --- | --- |
| `assets/themed/kdeglobals.tpl` | renders the active palette through the `themed/` template system |
| `assets/hooks/theme-set.d/kde-globals` | installs the rendered file on every theme change |
| `scripts/setup_kde_theme.sh` | installs both; no root required |

Wired to a **Match Omarchy Theme** button in the troubleshooting row, alongside the existing firewall and dependency buttons.

Colours are derived from `colors.toml` keys that `omarchy-theme-color` resolves for every theme, and surfaces are mixed between `background` and `foreground` rather than hardcoded, so light themes stay light. Verified: the template renders with **no unresolved tokens against all 22 themes Omarchy ships**, and the mix direction inverts correctly (`flexoki-light` → window `255,252,240`, view `245,243,231`; `vantablack` → `0,0,0` and `10,10,10`). Any existing `kdeglobals` is backed up before replacement.

Because it's just a KDE colour scheme, Dolphin, Gwenview, Okular and Ark follow the theme too.

## Why SMS shows numbers instead of names

Separately: `kdeconnect-sms` lists every conversation by phone number when `kpeoplevcard` is missing. KDE Connect writes the phone's address book to `~/.local/share/kpeoplevcard/kdeconnect-<id>/` as vCards, but nothing resolves them to names without that KPeople backend. On the machine I hit this on, the directory existed and held zero vCards.

It's an AUR package, so `install_dependencies.sh` offers it as a **prompted, optional** step after the required repo packages rather than bundling it — and skips it entirely when non-interactive or when no AUR helper is present.

## Incidental bug fix

`validate.sh`'s repo-root lookup breaks when `CDPATH` is set:

```bash
repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
```

`cd` echoes the resolved path when it resolves via `CDPATH`, so the captured value comes back **doubled** and the script operates on a garbage path. Found it because my own `CDPATH` contains the directory the clone lives in. Hardened to `CDPATH= cd -- ...` in `validate.sh` and the new script.

## Testing

- `scripts/validate.sh` passes — 73 tests, no qmllint errors.
- The 7 new qmllint warnings are the same `missing-property`/`unqualified` diagnostics the existing `Install Dependencies` and `Start Service` buttons already emit (the documented host-import limitation), not a new class.
- `setup_kde_theme.sh` exercised end-to-end from a clean slate: template + hook installed, `kdeglobals` generated, no unresolved tokens.
- Runtime-verified in a live Omarchy 4.0.0.alpha shell: the panel loads with no new QML errors, and `kdeconnect-sms` restarts rendering in the active theme instead of Breeze light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AogmCL7xJjsoCueCoLEoLX
